### PR TITLE
refactor: Fixture enhancement for capture network monitor for all pages

### DIFF
--- a/tests/components/user-management.spec.ts
+++ b/tests/components/user-management.spec.ts
@@ -37,8 +37,8 @@ test.describe('User management', { tag: '@component' }, () => {
     }
   });
 
-  test('Filter users by role', async ({ app, session }) => {
-    await session({ role: 'Administrator' });
+  test('Filter users by role', async ({ session }) => {
+    const app = await session({ role: 'Administrator' });
     await app.dashboardPage.navigateToMenu(USER_MANAGEMENT);
     const filteredRole = (await app.usersPage.filterUsersByRole()).toLowerCase();
     const uniqueColumValues = new Set(await app.usersPage.getColumnValues('Role'));
@@ -48,8 +48,8 @@ test.describe('User management', { tag: '@component' }, () => {
 
   const searchFieldKey = { name: 'fullName', email: 'emailAddress' };
   for (const [field, key] of Object.entries(searchFieldKey)) {
-    test(`Search users by ${field}`, async ({ app, session }) => {
-      await session({ role: 'Administrator' });
+    test(`Search users by ${field}`, async ({ session }) => {
+      const app = await session({ role: 'Administrator' });
       await app.dashboardPage.navigateToMenu(USER_MANAGEMENT);
       const searchString = getSearchString(String(getRandomValue(users)[key as keyof TestUser]));
       const tableTextContents = await app.usersPage.searchUsersBy(searchString);

--- a/tests/e2e/user-management.spec.ts
+++ b/tests/e2e/user-management.spec.ts
@@ -10,10 +10,9 @@ import { getNewUser, type TestUser } from '../../test-data/test-users';
 
 test.describe('User management E2E', { tag: '@e2e' }, () => {
   test('Admin login to Role Vault, add new user, added new user login, delete user, verify removed user cannot login', async ({
-    app,
     session,
   }) => {
-    await session({ role: 'Administrator' });
+    const app = await session({ role: 'Administrator' });
     const newUser: TestUser = { ...getNewUser(), role: 'Viewer' };
 
     await test.step('Admin adds a new user and verifies user is added', async () => {
@@ -25,7 +24,7 @@ test.describe('User management E2E', { tag: '@e2e' }, () => {
 
     let newUserApp: App;
     await test.step('Newly added user login to Role Vault and logs out', async () => {
-      newUserApp = await session({ newSession: true });
+      newUserApp = await session();
       await newUserApp.homePage.login(newUser);
       await newUserApp.assert.expectToastMessage(`Welcome back, ${newUser.fullName}!`);
       await newUserApp.dashboardPage.assertIsVisible();

--- a/utils/helper.ts
+++ b/utils/helper.ts
@@ -3,6 +3,8 @@
  * Provides common functionality for random selection and string manipulation.
  */
 
+import type { Page, TestInfo } from '@playwright/test';
+
 /**
  * Selects a random element from an array.
  *
@@ -48,4 +50,20 @@ export function getSearchString(str: string): string {
 
 export function getArg(str: string): string | undefined {
   return process.argv.find((arg) => arg.includes(str));
+}
+
+export async function captureScreenshot(testInfo: TestInfo, page: Page, screenshotName: string): Promise<void> {
+  try {
+    const screenshot = await page.screenshot({
+      path: `screenshots/${screenshotName.replace(/[^a-zA-Z0-9]/g, '_')}_${Date.now()}.png`,
+      fullPage: true,
+      scale: 'css',
+    });
+    await testInfo.attach(screenshotName, {
+      body: screenshot,
+      contentType: 'image/png',
+    });
+  } catch (error) {
+    console.warn(`Could not capture screenshot with name ${screenshotName}:`, error);
+  }
 }

--- a/utils/networkMonitor.ts
+++ b/utils/networkMonitor.ts
@@ -203,7 +203,8 @@ export function generateNetworkReportCSV(): void {
  */
 export async function setupNetworkMonitoring(
   page: Page,
-  testInfo: TestInfo
+  testInfo: TestInfo,
+  pageIdentifier: string
 ): Promise<{ getNetworkData: () => HttpRequestRecord[]; attachReport: () => Promise<void> }> {
   const httpRequestRecords: HttpRequestRecord[] = [];
   // Set up request finished listener
@@ -234,7 +235,7 @@ export async function setupNetworkMonitoring(
     attachReport: async (): Promise<void> => {
       const networkRequestJSON = saveTestNetworkData(testInfo, httpRequestRecords);
       if (networkRequestJSON) {
-        await testInfo.attach('Network Requests JSON Report', {
+        await testInfo.attach(`${pageIdentifier}_Network_Requests_JSON_Report`, {
           body: networkRequestJSON,
           contentType: 'application/json',
         });


### PR DESCRIPTION
refactor(fixtures): enhance test fixtures with improved network monitoring and screenshot capture

- Add network monitoring to page fixture with configurable page identifier
- Extract screenshot capture logic to reusable helper function
- Refactor session fixture to always create new browser contexts for proper isolation
- Remove newSession option from session fixture (always creates new sessions now)
- Add per-session network monitoring with unique identifiers
- Add screenshot capture on failure for all session pages
- Remove auto-fixtures (fullPageScreenshotOnFailure and networkMonitor) in favor of explicit setup
- Update networkMonitor utility to accept pageIdentifier parameter for better report naming
- Add error handling for screenshot capture and network report attachment

Resolves Issue: #4 