### PR TITLE
feat: add authentication storage state management for test sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ screenshots/
 allure-results/
 allure-report
 network-reports
+.auth

--- a/constants.ts
+++ b/constants.ts
@@ -8,3 +8,4 @@ export const USER_ALREADY_EXISTS = 'User already exists with this email';
 export const LOGOUT_SUCCESS = 'Logged out successfully';
 export const ACCOUNT_CREATE_SUCCESS = 'Account created successfully';
 export const USER_CREATE_SUCCESS = 'User created successfully';
+export const STORAGE_STATE_DIR = '.auth';

--- a/fixtures/storageState.ts
+++ b/fixtures/storageState.ts
@@ -1,0 +1,36 @@
+import * as fs from 'fs';
+import { STORAGE_STATE_DIR } from '../constants';
+import path from 'path';
+import type { Role } from '../test-data/test-users';
+import type { BrowserContext } from '@playwright/test';
+
+/**
+ * Ensures the storage state directory exists
+ */
+function ensureStorageStateDir(): void {
+  if (!fs.existsSync(STORAGE_STATE_DIR)) {
+    fs.mkdirSync(STORAGE_STATE_DIR, { recursive: true });
+  }
+}
+
+/**
+ * Gets the storage state file path for a specific role
+ */
+export function getStorageStatePath(role: Role): string {
+  return path.join(STORAGE_STATE_DIR, `${role}.json`);
+}
+
+/**
+ * Checks if storage state file exists for a role
+ */
+export function hasStorageState(role: Role): boolean {
+  return fs.existsSync(getStorageStatePath(role));
+}
+
+/**
+ * storage state for a specific role
+ */
+export async function saveStorageState(context: BrowserContext, role: Role): Promise<void> {
+  ensureStorageStateDir();
+  await context.storageState({ path: getStorageStatePath(role) });
+}


### PR DESCRIPTION
- Create storageState utility module for managing browser storage states
- Add storage state support to session fixture with role-based caching
- Update launchApp to handle authenticated/unauthenticated sessions
- Add STORAGE_STATE_DIR constant and update .gitignore
- Optimize test execution by reusing authenticated sessions across tests

This enhancement reduces test execution time by persisting authentication state and reusing it across test sessions for different user roles.